### PR TITLE
unifi.Device.SpeedTestStatus.Latency 5.8 API Fix

### DIFF
--- a/device.go
+++ b/device.go
@@ -570,7 +570,7 @@ type Device struct {
 	NumHandheld            int              `json:"num_handheld,omitempty"`
 	NumMobile              int              `json:"num_mobile,omitempty"`
 	SpeedtestStatus        struct {
-		Latency        string  `json:"latency"`
+		Latency        float64  `json:"latency"`
 		Rundate        int     `json:"rundate"`
 		Runtime        int     `json:"runtime"`
 		StatusDownload int     `json:"status_download"`


### PR DESCRIPTION
dim13, I stumbled across your library while working on a project to pull time series data from Unifi devices. I only have a version 5.8 controller to test on and with your master branch, I wasn't able to unmarshal the unifi.Device.SpeedTestStatus.Latency field into a string (I'm assuming because of the type that is returned has changed between 5.7.x and 5.8.x versions of the API.) This should work with the 5.7 version of the API as float64 can account for decimals. This is my first pull request so let me know if you'd like me to change anything. I'll also look for other ways to help out and improve the library as I go. Thanks!